### PR TITLE
Add Purul website with Node backend

### DIFF
--- a/purul-site/README.md
+++ b/purul-site/README.md
@@ -1,0 +1,32 @@
+# Purul Website
+
+This folder contains a simple Node.js/Express web application with a static front end.
+It demonstrates a small product API and can be deployed to AWS Elastic Beanstalk.
+
+## Requirements
+- Node.js 14 or later
+
+## Local Development
+1. Install dependencies
+   ```bash
+   npm install
+   ```
+2. Start the server
+   ```bash
+   npm start
+   ```
+3. Visit `http://localhost:3000` in your browser.
+
+## Deploy to AWS Elastic Beanstalk
+1. Install the [AWS Elastic Beanstalk CLI](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/eb-cli3-install.html).
+2. Initialize your EB project:
+   ```bash
+   eb init -p node.js-14 purul-site
+   ```
+3. Create an environment and deploy:
+   ```bash
+   eb create purul-env
+   eb open
+   ```
+
+AWS will provision the infrastructure and host the app using the Node.js platform.

--- a/purul-site/data/products.json
+++ b/purul-site/data/products.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": 1,
+    "name": "Gear Housing",
+    "description": "Durable injection moulded gear housing for industrial machines.",
+    "price": 12.99
+  },
+  {
+    "id": 2,
+    "name": "Valve Cover",
+    "description": "High precision moulded valve cover used in automotive engines.",
+    "price": 7.5
+  },
+  {
+    "id": 3,
+    "name": "Enclosure",
+    "description": "Weather-resistant plastic enclosure for electronic devices.",
+    "price": 15.0
+  }
+]

--- a/purul-site/package.json
+++ b/purul-site/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "purul-site",
+  "version": "1.0.0",
+  "description": "Website for Purul, an injection moulded parts supplier",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "nodemon server.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": ["purul", "injection", "moulded", "parts"],
+  "author": "",
+  "license": "MIT",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "nodemon": "^2.0.22"
+  }
+}

--- a/purul-site/public/app.js
+++ b/purul-site/public/app.js
@@ -1,0 +1,17 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const list = document.getElementById('product-list');
+    if (list) {
+        fetch('/api/products')
+            .then(resp => resp.json())
+            .then(data => {
+                data.forEach(prod => {
+                    const li = document.createElement('li');
+                    li.textContent = `${prod.name} - $${prod.price} : ${prod.description}`;
+                    list.appendChild(li);
+                });
+            })
+            .catch(err => {
+                list.innerHTML = 'Failed to load products.';
+            });
+    }
+});

--- a/purul-site/public/contact.html
+++ b/purul-site/public/contact.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Purul - Contact</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>Purul</h1>
+        <nav>
+            <a href="index.html">Home</a>
+            <a href="products.html">Products</a>
+            <a href="contact.html">Contact</a>
+        </nav>
+    </header>
+    <main>
+        <section>
+            <h2>Contact Us</h2>
+            <form>
+                <label>Name:<br><input type="text" name="name"></label><br>
+                <label>Email:<br><input type="email" name="email"></label><br>
+                <label>Message:<br><textarea name="message"></textarea></label><br>
+                <button type="submit">Send</button>
+            </form>
+        </section>
+    </main>
+    <footer>
+        <p>&copy; 2024 Purul. All rights reserved.</p>
+    </footer>
+</body>
+</html>

--- a/purul-site/public/index.html
+++ b/purul-site/public/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Purul - Injection Moulded Parts</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>Purul</h1>
+        <nav>
+            <a href="index.html">Home</a>
+            <a href="products.html">Products</a>
+            <a href="contact.html">Contact</a>
+        </nav>
+    </header>
+    <main>
+        <section>
+            <h2>Welcome to Purul</h2>
+            <p>Your reliable supplier of high-quality injection moulded parts.</p>
+        </section>
+    </main>
+    <footer>
+        <p>&copy; 2024 Purul. All rights reserved.</p>
+    </footer>
+</body>
+</html>

--- a/purul-site/public/products.html
+++ b/purul-site/public/products.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Purul - Products</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>Purul</h1>
+        <nav>
+            <a href="index.html">Home</a>
+            <a href="products.html">Products</a>
+            <a href="contact.html">Contact</a>
+        </nav>
+    </header>
+    <main>
+        <section>
+            <h2>Our Products</h2>
+            <ul id="product-list"></ul>
+        </section>
+    </main>
+    <footer>
+        <p>&copy; 2024 Purul. All rights reserved.</p>
+    </footer>
+    <script src="app.js"></script>
+</body>
+</html>

--- a/purul-site/public/style.css
+++ b/purul-site/public/style.css
@@ -1,0 +1,33 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+}
+
+header {
+    background-color: #004080;
+    color: white;
+    padding: 1rem;
+}
+
+nav a {
+    color: white;
+    margin-right: 1rem;
+    text-decoration: none;
+}
+
+footer {
+    background-color: #f4f4f4;
+    padding: 1rem;
+    text-align: center;
+}
+
+#product-list {
+    list-style: none;
+    padding: 0;
+}
+
+#product-list li {
+    border-bottom: 1px solid #ccc;
+    padding: 0.5rem 0;
+}

--- a/purul-site/server.js
+++ b/purul-site/server.js
@@ -1,0 +1,24 @@
+const express = require('express');
+const path = require('path');
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+// Static files
+app.use(express.static(path.join(__dirname, 'public')));
+
+// Products data
+const products = require('./data/products.json');
+
+// API endpoint
+app.get('/api/products', (req, res) => {
+  res.json(products);
+});
+
+// Default route
+app.get('*', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'index.html'));
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add `purul-site` project with Node/Express backend
- serve simple product API and frontend HTML pages
- include AWS deployment instructions

## Testing
- `script/cibuild` *(fails: jekyll not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685b019970248327832a6daaaefd113f